### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "A plugin for Gulp",
   "keywords": [
     "gulp plugin",
+    "gulpplugin",
     "layoutize",
     "templatize",
     "template",
     "gulp consolidate"
   ],
+  "homepage": "https://github.com/rowoot/gulp-layoutize/",
+  "bugs": "https://github.com/rowoot/gulp-layoutize/issues/",
   "author": {
     "name": "Micheal Benedict (@micheal)",
     "email": "",


### PR DESCRIPTION
Adding keyword so module gets added to http://gulpjs.com/plugins/
Should now pass http://package-json-validator.com/ validation
