### PR TITLE
Pass current file into locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Default: `{}`
 Required: `true`
 
 The locals object is passed as template variables to the templating engine. Refer to the templating engine guides on how to use variables in the template.
+Also, you have some predefined locals, refering to the current file:
+
+* content (String): content of the current file
+* file (Object): [vinyl](https://github.com/wearefractal/vinyl#file) file object with filename, path, etc.
 
 
 ## License

--- a/fixtures/template.jade
+++ b/fixtures/template.jade
@@ -4,3 +4,4 @@ html(lang="en")
     title= pageTitle
   body
     != content
+    p= file.path

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = function (opts) {
 
 		if (file.isBuffer()) {
 			fn(arg, extend(true, {
+				file: file,
 				content: String(file.contents)
 			}, opts.locals),
       		function (err, html) {

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ it('should render template when using templatePath', function (cb) {
 	});
 
 	stream.on('data', function (file) {
-		assert.equal('<!DOCTYPE html><html lang="en"><head><title>Title</title></head><body><h1>Test</h1></body></html>', file.contents.toString());
+		assert.equal('<!DOCTYPE html><html lang="en"><head><title>Title</title></head><body><h1>Test</h1><p>file.html</p></body></html>', file.contents.toString());
 		cb();
 	});
 
@@ -35,7 +35,7 @@ it('should render template when using template (content)', function (cb) {
 	});
 
 	stream.on('data', function (file) {
-		assert.equal('<!DOCTYPE html><html lang="en"><head><title>Title</title></head><body><h1>Test</h1></body></html>', file.contents.toString());
+		assert.equal('<!DOCTYPE html><html lang="en"><head><title>Title</title></head><body><h1>Test</h1><p>file.html</p></body></html>', file.contents.toString());
 		cb();
 	});
 


### PR DESCRIPTION
This feature could be useful when you creating navigation menu in layout. Now I can't get the current filename. This fix adds ability to generate menu like this:

``` jade
ul
    each item in menu
        li(class= item.name == file.path ? 'active' : '')
             a(href=item.href)= item.name
```
